### PR TITLE
Refine home layout and add intro overlays

### DIFF
--- a/education.html
+++ b/education.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
-<body class="interior-page education-page">
+<body class="interior-page education-page" data-intro-text="Education – USC MS Computer Science and IIT Delhi Mathematics &amp; Computing">
     <header class="site-header">
         <nav class="primary-nav" aria-label="Primary">
             <ul>
@@ -30,8 +30,8 @@
         <section class="page-hero">
             <div class="page-hero-inner">
                 <p class="page-kicker">Education</p>
-                <h1 data-animate-words>Charting my academic galaxies across continents</h1>
-                <p class="page-summary">A dual-hemisphere journey spanning IIT Delhi and USC, with coursework that powers practical, explainable AI.</p>
+                <h1 data-animate-words>Education</h1>
+                <p class="page-summary">Coursework and milestones from USC's MS in Computer Science and IIT Delhi's Mathematics and Computing program.</p>
             </div>
         </section>
 

--- a/experience.html
+++ b/experience.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
-<body class="interior-page experience-page">
+<body class="interior-page experience-page" data-intro-text="Experience – Goldman Sachs, SAIL KAIST, Adobe">
     <header class="site-header">
         <nav class="primary-nav" aria-label="Primary">
             <ul>
@@ -30,8 +30,8 @@
         <section class="page-hero">
             <div class="page-hero-inner">
                 <p class="page-kicker">Experience</p>
-                <h1 data-animate-words>Mapping the professional constellations I've engineered</h1>
-                <p class="page-summary">From quant finance to explainable AI, I build systems that scale responsibly and feel futuristic from day one.</p>
+                <h1 data-animate-words>Professional Experience</h1>
+                <p class="page-summary">Roles at Goldman Sachs, SAIL KAIST, and Adobe where I worked on quantitative research, explainable AI, and model optimization.</p>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -39,11 +39,6 @@
                     <p class="identity-description">Hi, I'm Ayush Goyal, a Computer Science graduate student at the University of Southern California, actively seeking New Grad roles (2026). I hold a bachelor's in Mathematics &amp; Computing from IIT Delhi. My expertise spans NLP, Computer Vision, XAI, and multimodal AI.</p>
                     <p class="identity-description">I'm passionate about applying AI to real-world problems and excited to contribute to innovative teams in industry.</p>
                 </div>
-                <div class="identity-search" data-search-component>
-                    <label for="home-search" class="sr-only">Search the portfolio</label>
-                    <input id="home-search" type="text" placeholder="Search experiences, projects, publications, or skills" data-search-input>
-                    <button type="button" data-search-button aria-label="Search"><i class="fas fa-search" aria-hidden="true"></i></button>
-                </div>
                 <div class="identity-links">
                     <a href="Ayush_Goyal_resume.pdf" target="_blank" rel="noopener" class="resume-chip">
                         <img src="assets/icons/resume.svg" alt="Resume icon" aria-hidden="true">
@@ -62,117 +57,9 @@
                         <a href="https://github.com/NormalVad" target="_blank" rel="noopener" class="social-link" aria-label="GitHub">
                             <img src="assets/icons/github.svg" alt="GitHub">
                         </a>
-                        <div class="hero-socials" aria-label="Social links">
-                            <a href="mailto:ayushgoyal5720@gmail.com" class="social-link" title="Email">
-                                <img src="assets/icons/email.svg" alt="Email">
-                            </a>
-                            <a href="https://www.linkedin.com/in/ayushgoyal0507/" target="_blank" rel="noopener" class="social-link" title="LinkedIn">
-                                <img src="assets/icons/linkedin.svg" alt="LinkedIn">
-                            </a>
-                            <a href="https://x.com/anakinwader57" target="_blank" rel="noopener" class="social-link" title="X (Twitter)">
-                                <img src="assets/icons/x.svg" alt="X (Twitter)">
-                            </a>
-                            <a href="https://github.com/NormalVad" target="_blank" rel="noopener" class="social-link" title="GitHub">
-                                <img src="assets/icons/github.svg" alt="GitHub">
-                            </a>
-                        </div>
                     </div>
                 </div>
             </article>
-        </section>
-
-        <section class="home-overview">
-            <div class="section-intro">
-                <h2 class="interactive-heading" tabindex="0">
-                    <span>Explore my work</span>
-                    <img src="assets/previews/projects.svg" alt="" aria-hidden="true">
-                </h2>
-                <p>Navigate through the areas that define my craft — refined experience, impactful projects, and a strong academic foundation.</p>
-            </div>
-            <div class="overview-grid">
-                <article class="overview-card">
-                    <a href="experience.html" class="overview-link">
-                        <h3 class="interactive-heading">
-                            <span>Experience</span>
-                            <img src="assets/previews/experience.svg" alt="" aria-hidden="true">
-                        </h3>
-                        <p>Discover roles where I've built quant finance pipelines, advanced explainable AI, and delivered production-ready research.</p>
-                        <span class="overview-cta">View Experience</span>
-                    </a>
-                </article>
-                <article class="overview-card">
-                    <a href="projects.html" class="overview-link">
-                        <h3 class="interactive-heading">
-                            <span>Projects</span>
-                            <img src="assets/previews/projects.svg" alt="" aria-hidden="true">
-                        </h3>
-                        <p>Explore research-driven builds across NLP, computer vision, and trustworthy AI with open-source implementations.</p>
-                        <span class="overview-cta">Browse Projects</span>
-                    </a>
-                </article>
-                <article class="overview-card">
-                    <a href="education.html" class="overview-link">
-                        <h3 class="interactive-heading">
-                            <span>Education</span>
-                            <img src="assets/previews/education.svg" alt="" aria-hidden="true">
-                        </h3>
-                        <p>See the academic journey that anchors my engineering mindset — from IIT Delhi to USC Computer Science.</p>
-                        <span class="overview-cta">View Education</span>
-                    </a>
-                </article>
-            </div>
-        </section>
-
-        <section class="contact-section" id="contact">
-            <div class="section-intro">
-                <h2 class="interactive-heading" tabindex="0">
-                    <span>Let's build something</span>
-                    <img src="assets/previews/contact.svg" alt="" aria-hidden="true">
-                </h2>
-                <p>Whether it's research, product engineering, or AI innovation, I'm ready to collaborate.</p>
-            </div>
-            <div class="contact-card">
-                <div class="contact-info">
-                    <h3>Contact Information</h3>
-                    <p>I'd love to hear from you. Share a little about what you're building, and I'll reply within two business days.</p>
-                    <ul class="contact-list">
-                        <li>
-                            <img src="assets/icons/email.svg" alt="" aria-hidden="true">
-                            <a href="mailto:ayushgoyal5720@gmail.com">ayushgoyal5720@gmail.com</a>
-                        </li>
-                        <li>
-                            <img src="assets/icons/linkedin.svg" alt="" aria-hidden="true">
-                            <a href="https://www.linkedin.com/in/ayushgoyal0507/" target="_blank" rel="noopener">linkedin.com/in/ayushgoyal0507</a>
-                        </li>
-                        <li>
-                            <img src="assets/icons/github.svg" alt="" aria-hidden="true">
-                            <a href="https://github.com/NormalVad" target="_blank" rel="noopener">github.com/NormalVad</a>
-                        </li>
-                    </ul>
-                </div>
-                <form id="contact-form" class="contact-form">
-                    <div class="form-row">
-                        <div class="form-field">
-                            <label for="first-name">First name</label>
-                            <input type="text" id="first-name" name="first_name" autocomplete="given-name" required>
-                        </div>
-                        <div class="form-field">
-                            <label for="last-name">Last name</label>
-                            <input type="text" id="last-name" name="last_name" autocomplete="family-name" required>
-                        </div>
-                    </div>
-                    <div class="form-field">
-                        <label for="email">Email</label>
-                        <input type="email" id="email" name="email" autocomplete="email" required>
-                    </div>
-                    <div class="form-field">
-                        <label for="message">Message</label>
-                        <textarea id="message" name="message" rows="5" required></textarea>
-                    </div>
-                    <button type="submit" class="send-button">Send Message</button>
-                    <p class="form-status" role="status" aria-live="polite"></p>
-                </form>
-            </div>
         </section>
     </main>
 

--- a/projects.html
+++ b/projects.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
-<body class="interior-page projects-page">
+<body class="interior-page projects-page" data-intro-text="Projects – PETRv2 Adaptive Extensions, Intent based CounterSpeech, Claim Span Identification">
     <header class="site-header">
         <nav class="primary-nav" aria-label="Primary">
             <ul>
@@ -30,8 +30,8 @@
         <section class="page-hero">
             <div class="page-hero-inner">
                 <p class="page-kicker">Projects</p>
-                <h1 data-animate-words>Prototyping the future with responsible intelligence</h1>
-                <p class="page-summary">A curated set of research and product builds spanning multimodal AI, trustworthy NLP, and human-centered tooling.</p>
+                <h1 data-animate-words>Projects</h1>
+                <p class="page-summary">Detailed notes on PETRv2 adaptive extensions, intent based counter speech, and claim span identification projects.</p>
             </div>
         </section>
 

--- a/script.js
+++ b/script.js
@@ -4,7 +4,100 @@ document.addEventListener('DOMContentLoaded', () => {
     const themeToggle = document.getElementById('theme-toggle');
     const navPreview = document.querySelector('.nav-preview');
     const navLinks = document.querySelectorAll('.primary-nav a[data-preview]');
-    
+
+    initializePageIntro();
+
+    function initializePageIntro() {
+        const introText = document.body.dataset.introText;
+        if (!introText) {
+            return;
+        }
+        createPageIntro(introText.trim());
+    }
+
+    function createPageIntro(text) {
+        const overlay = document.createElement('div');
+        overlay.className = 'page-intro-overlay';
+        overlay.innerHTML = `
+            <div class="overlay-background" aria-hidden="true"></div>
+            <div class="overlay-content">
+                <p class="overlay-text" aria-live="polite"></p>
+                <span class="overlay-hint">Tap or press Esc/Enter to continue</span>
+            </div>
+        `;
+
+        document.body.classList.add('intro-active');
+        document.body.appendChild(overlay);
+
+        const overlayText = overlay.querySelector('.overlay-text');
+        const words = text.split(/\s+/);
+        let index = 0;
+        let overlayHidden = false;
+        let typingInterval = null;
+
+        const finishTyping = () => {
+            if (typingInterval) {
+                window.clearInterval(typingInterval);
+                typingInterval = null;
+            }
+        };
+
+        const cleanup = () => {
+            document.removeEventListener('keydown', keyHandler);
+            overlay.removeEventListener('click', skipHandler);
+        };
+
+        const hideOverlay = (delay = 0) => {
+            if (overlayHidden) return;
+            overlayHidden = true;
+            cleanup();
+            window.setTimeout(() => {
+                overlay.classList.add('is-hidden');
+                document.body.classList.remove('intro-active');
+                window.setTimeout(() => overlay.remove(), 600);
+            }, delay);
+        };
+
+        const revealAndHide = () => {
+            finishTyping();
+            overlayText.textContent = text;
+            hideOverlay(200);
+        };
+
+        const keyHandler = (event) => {
+            if (event.key === 'Escape' || event.key === 'Esc' || event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                revealAndHide();
+            }
+        };
+
+        const skipHandler = () => {
+            revealAndHide();
+        };
+
+        document.addEventListener('keydown', keyHandler);
+        overlay.addEventListener('click', skipHandler);
+
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (prefersReducedMotion) {
+            overlayText.textContent = text;
+            hideOverlay(400);
+            return;
+        }
+
+        typingInterval = window.setInterval(() => {
+            if (index >= words.length) {
+                finishTyping();
+                hideOverlay(900);
+                return;
+            }
+
+            overlayText.textContent = words.slice(0, index + 1).join(' ');
+            index += 1;
+        }, 160);
+    }
+
     class SearchController {
         constructor(component) {
             this.component = component;
@@ -184,7 +277,6 @@ document.addEventListener('DOMContentLoaded', () => {
     function initializeSearch() {
         const components = document.querySelectorAll('[data-search-component]');
         if (!components.length) {
-            console.warn('No search components found');
             return;
         }
 

--- a/search-index.json
+++ b/search-index.json
@@ -1,22 +1,22 @@
 [
-    {
-      "title": "Home",
-      "url": "/index.html",
-      "content": "Ayush Goyal Graduate Research Assistant University of Southern California. I am actively seeking Summer Internship opportunities."
-    },
-    {
-      "title": "Experience",
-      "url": "/experience.html",
-      "content": "Goldman Sachs Quant Strategist Intern Summer Analyst Jun 2025 - Aug 2025 · New York, New York, United States. Mortgage Strats team engineered features and trained Random Forest scikit-learn model to predict Commercial Mortgage Backed Securities CMBS building valuations. IRP SMM Strats team extended Spreader algorithm in Java to improve performance under aggressive market conditions and investigated execution slippage against arrival market prices identifying opportunities worth approximately +$137K per $1mm duration traded. Machine Learning Quantitative Analysis Finance Java Python. SAIL, KAIST Research Assistant Aug 2023 - Jun 2024 · Daejeon, South Korea (Remote). Enhanced efficacy by leveraging dependency parser-based syntactic units, resulting in 7% increase in metric scores. Evaluated LIME, SHAP, IG, LRP and Attention on text classification models for Plug and Play XAI project. Developed a pipeline to provide the best explainer algorithm for particular text-based models to build trustworthiness. Adobe Research Intern Jun 2022 - Aug 2022 · Bengaluru, India (Remote). Implemented Quantization-Aware Training algorithm for GANs to optimize model size and performance in PyTorch. Analyzed layer-wise sensitivity of StyleGAN2 by estimating average Hessian matrix trace via Hutchinson algorithm. Achieved a high compression ratio of 6.5 times with negligible degradation in FID score compared to original model."
-    },
-    {
-      "title": "Projects",
-      "url": "/projects.html",
-      "content": "PETRv2 Multi-Frame Adaptive Extensions Enhanced PETRv2 model with adaptive multi-frame temporal fusion mechanisms for improved 3D object detection in autonomous driving scenarios. Computer Vision 3D Object Detection Autonomous Driving. Intent based CounterSpeech A system that generates counter-speech responses to combat online hate speech, considering the intent behind the hateful content. NLP AI Ethics. Claim Span Identification (CSI) An AI-powered tool that identifies and extracts claim spans from text, useful for fact-checking and argument analysis. NLP Fact-Checking."
-    },
-    {
-      "title": "Education",
-      "url": "/education.html",
-      "content": "University of Southern California (USC) MS in Computer Science | Jun 2024 - Dec 2025. GPA: 4.0/4.0. Relevant Coursework: CSCI 570 - Analysis and Design of Algorithms, CSCI 662 - Advanced Natural Language Processing (Ongoing), CSCI 545 - Introduction to Robotics (Ongoing). Indian Institute of Technology Delhi (IITD) BTech in Mathematics and Computing | Jul 2019 - Aug 2023. GPA: 9.078/10.0. Relevant Coursework: Algorithms, Data Structures, Machine Learning."
-    }
-  ]
+  {
+    "title": "Home",
+    "url": "/index.html",
+    "content": "Ayush Goyal CS graduate student at USC and IIT Delhi alumnus. Focused on NLP, computer vision, explainable AI, and multimodal systems while seeking 2026 new grad roles."
+  },
+  {
+    "title": "Experience",
+    "url": "/experience.html",
+    "content": "Goldman Sachs Quant Strategist Intern Summer Analyst Jun 2025 - Aug 2025 \u00b7 New York, New York, United States. Mortgage Strats team engineered features and trained Random Forest scikit-learn model to predict Commercial Mortgage Backed Securities CMBS building valuations. IRP SMM Strats team extended Spreader algorithm in Java to improve performance under aggressive market conditions and investigated execution slippage against arrival market prices identifying opportunities worth approximately +$137K per $1mm duration traded. Machine Learning Quantitative Analysis Finance Java Python. SAIL, KAIST Research Assistant Aug 2023 - Jun 2024 \u00b7 Daejeon, South Korea (Remote). Enhanced efficacy by leveraging dependency parser-based syntactic units, resulting in 7% increase in metric scores. Evaluated LIME, SHAP, IG, LRP and Attention on text classification models for Plug and Play XAI project. Developed a pipeline to provide the best explainer algorithm for particular text-based models to build trustworthiness. Adobe Research Intern Jun 2022 - Aug 2022 \u00b7 Bengaluru, India (Remote). Implemented Quantization-Aware Training algorithm for GANs to optimize model size and performance in PyTorch. Analyzed layer-wise sensitivity of StyleGAN2 by estimating average Hessian matrix trace via Hutchinson algorithm. Achieved a high compression ratio of 6.5 times with negligible degradation in FID score compared to original model."
+  },
+  {
+    "title": "Projects",
+    "url": "/projects.html",
+    "content": "PETRv2 Multi-Frame Adaptive Extensions Enhanced PETRv2 model with adaptive multi-frame temporal fusion for improved 3D object detection in autonomous driving scenarios. Intent based CounterSpeech Generates counter speech responses using intent-aware NLP pipelines. Claim Span Identification (CSI) Extracts claim spans from text to support fact-checking and argument analysis."
+  },
+  {
+    "title": "Education",
+    "url": "/education.html",
+    "content": "University of Southern California (USC) MS in Computer Science | Jun 2024 - Dec 2025. GPA: 3.9/4.0. Coursework includes Algorithms, Advanced Natural Language Processing, Robotics, Deep Learning, Advanced Computer Vision, and Digital Image Processing. Indian Institute of Technology Delhi (IITD) BTech in Mathematics and Computing | Jul 2019 - Aug 2023. CGPA: 9.078/10.0. Coursework spans Data Structures, Algorithms, NLP, Machine Learning, and Probability."
+  }
+]

--- a/style.css
+++ b/style.css
@@ -309,50 +309,11 @@ body.home-page .home-main {
     margin-top: 0.75rem;
 }
 
-.identity-search {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.75rem;
-    background: rgba(15, 23, 42, 0.8);
-    border-radius: 16px;
-    border: 1px solid var(--glass-border);
-    padding: 0.75rem 0.75rem 0.75rem 1.15rem;
-    box-shadow: 0 20px 60px rgba(8, 47, 73, 0.35);
-}
-
-.identity-search input {
-    background: transparent;
-    border: none;
-    color: var(--primary-text);
-    font-size: 1rem;
-    outline: none;
-}
-
-.identity-search input::placeholder {
-    color: rgba(148, 163, 184, 0.8);
-}
-
-.identity-search button {
-    background: linear-gradient(120deg, var(--accent), var(--accent-purple));
-    border: none;
-    color: #fff;
-    border-radius: 14px;
-    padding: 0.65rem 1.2rem;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.identity-search button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 30px rgba(56, 189, 248, 0.25);
-}
-
 .identity-links {
     display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.2rem;
 }
 
 .resume-chip {
@@ -397,6 +358,14 @@ body.home-page .home-main {
     pointer-events: auto;
 }
 
+@media (hover: none) {
+    .social-tray {
+        opacity: 1;
+        transform: none;
+        pointer-events: auto;
+    }
+}
+
 .social-link {
     width: 42px;
     height: 42px;
@@ -433,6 +402,100 @@ body.light-theme .social-link:hover,
 body.light-theme .social-link:focus-visible {
     box-shadow: 0 14px 32px rgba(15, 23, 42, 0.24);
     border-color: rgba(59, 130, 246, 0.45);
+}
+
+
+body.intro-active {
+    overflow: hidden;
+}
+
+.page-intro-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    display: grid;
+    place-items: center;
+    pointer-events: auto;
+    overflow: hidden;
+    transition: opacity 0.6s ease, visibility 0.6s ease;
+}
+
+.page-intro-overlay.is-hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.page-intro-overlay .overlay-background {
+    position: absolute;
+    inset: -20%;
+    background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.35), transparent 60%),
+                radial-gradient(circle at 80% 30%, rgba(129, 140, 248, 0.3), transparent 55%),
+                linear-gradient(135deg, rgba(4, 12, 24, 0.92), rgba(12, 30, 54, 0.88));
+    background-size: 180% 180%;
+    animation: overlayFlow 18s ease-in-out infinite;
+}
+
+.page-intro-overlay .overlay-content {
+    position: relative;
+    padding: clamp(2rem, 5vw, 3rem);
+    border-radius: 28px;
+    border: 1px solid var(--glass-border);
+    background: rgba(8, 13, 24, 0.6);
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+    max-width: min(640px, 90%);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+}
+
+.page-intro-overlay .overlay-text {
+    margin: 0;
+    font-size: clamp(1.3rem, 4vw, 2.25rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    line-height: 1.5;
+    color: var(--primary-text);
+}
+
+.page-intro-overlay .overlay-hint {
+    display: block;
+    margin-top: 1.5rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+body.light-theme .page-intro-overlay .overlay-content {
+    background: rgba(241, 245, 249, 0.8);
+    color: #0f172a;
+}
+
+body.light-theme .page-intro-overlay .overlay-text {
+    color: #0f172a;
+}
+
+body.light-theme .page-intro-overlay .overlay-hint {
+    color: rgba(15, 23, 42, 0.6);
+}
+
+@keyframes overlayFlow {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .page-intro-overlay .overlay-background {
+        animation: none;
+    }
 }
 
 .site-footer {


### PR DESCRIPTION
## Summary
- Simplified the home page into a single hero card, keeping the resume link visible and revealing social links on hover while removing duplicate sections
- Replaced the experience, projects, and education hero copy with direct descriptions and added animated intro overlays that type each page summary
- Updated shared styling and the search index to align with the streamlined content and new interactions

## Testing
- Manual verification: `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68dcc375096883268e71f62313cc1b8e